### PR TITLE
Add agent utils and CLI example

### DIFF
--- a/examples/show_agent_prompt.py
+++ b/examples/show_agent_prompt.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Example CLI to load SystemPrompt.xml and outline agent actions."""
+import argparse
+from pathlib import Path
+import sys
+
+# Allow imports from the repository root when executed as a script
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.agent_utils import parse_system_prompt, generate_prompt
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render a prompt from SystemPrompt.xml")
+    parser.add_argument(
+        "xml_path",
+        nargs="?",
+        default="SystemPrompt.xml",
+        help="Path to the SystemPrompt.xml file",
+    )
+    args = parser.parse_args()
+
+    xml_file = Path(args.xml_path)
+    sections = parse_system_prompt(str(xml_file))
+    prompt_text = generate_prompt(sections)
+
+    print(prompt_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/agent_utils.py
+++ b/utils/agent_utils.py
@@ -1,0 +1,54 @@
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+@dataclass
+class Section:
+    """Represents a section from the system prompt."""
+    title: str
+    context: Optional[str] = None
+    instructions: List[str] = field(default_factory=list)
+    list_items: List[str] = field(default_factory=list)
+
+
+def parse_system_prompt(xml_path: str) -> List[Section]:
+    """Parse a SystemPrompt.xml file into structured sections."""
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+    sections: List[Section] = []
+    current: Optional[Section] = None
+
+    for elem in root:
+        if elem.tag == "section_title":
+            if current:
+                sections.append(current)
+            current = Section(title=(elem.text or "").strip())
+        elif current is not None:
+            if elem.tag == "context":
+                current.context = ("".join(elem.itertext())).strip()
+            elif elem.tag == "instructions":
+                current.instructions.append("".join(elem.itertext()).strip())
+            elif elem.tag == "list":
+                for item in elem.findall("item"):
+                    text = "".join(item.itertext()).strip()
+                    if text:
+                        current.list_items.append(text)
+    if current:
+        sections.append(current)
+    return sections
+
+
+def generate_prompt(sections: List[Section]) -> str:
+    """Generate a simple text prompt from parsed sections."""
+    lines: List[str] = []
+    for sec in sections:
+        lines.append(f"# {sec.title}")
+        if sec.context:
+            lines.append(sec.context)
+        for inst in sec.instructions:
+            lines.append(f"- {inst}")
+        if sec.list_items:
+            for item in sec.list_items:
+                lines.append(f"* {item}")
+        lines.append("")
+    return "\n".join(lines).strip()


### PR DESCRIPTION
## Summary
- parse `SystemPrompt.xml` into structured sections
- provide a helper to generate textual prompts
- include an example CLI to render the prompt

## Testing
- `python3 -m py_compile utils/agent_utils.py examples/show_agent_prompt.py`
- `python3 examples/show_agent_prompt.py SystemPrompt.xml | head`